### PR TITLE
Update test for rendering slowdown

### DIFF
--- a/ui-tests/search-page.ui.ts
+++ b/ui-tests/search-page.ui.ts
@@ -417,6 +417,8 @@ test.describe('Sidebar Tests', () => {
       { name: 'LOCAL-SYNTH_04', full: 'LOCAL-SYNTH_04<1020Request Access' }
     ];
   
+    // sleep for 1 second for slow loading
+    await page.waitForTimeout(1000);
     await verifyPatientData(page, expectedValues);
   
     // Clinical data rows to verify
@@ -450,7 +452,9 @@ test.describe('Sidebar Tests', () => {
       { name: 'LOCAL-SYNTH_02', full: 'LOCAL-SYNTH_02420' }, 
       { name: 'LOCAL-SYNTH_04', full: 'LOCAL-SYNTH_04<1020Request Access' }
     ];
-  
+    
+    // sleep for 1 second for slow loading
+    await page.waitForTimeout(1000);
     await verifyPatientData(page, expectedValues);
   
     // Clinical data rows to verify
@@ -614,6 +618,8 @@ test.describe('Sidebar Tests', () => {
     ];
 
     // Verify patient data
+    // sleep for 1 second for slow loading
+    await page.waitForTimeout(1000);
     await verifyPatientData(page, expectedValues);
 
     // Check LOCAL Node
@@ -631,6 +637,8 @@ test.describe('Sidebar Tests', () => {
     ];
 
     // Verify updated patient data
+    // sleep for 1 second for slow loading
+    await page.waitForTimeout(1000);
     await verifyPatientData(page, expectedValuesCheck);
 
     await clickResetButton(page);


### PR DESCRIPTION
# Description

Updated the Playwright tests to ensure they run reliably both with and without the --ui flag. In headless mode (without --ui), the tests were executing faster than the DOM could render, leading to failures. Adjustments were made to account for rendering timing, including added waits where necessary.