### PR TITLE
Fixup: Threshold->maxPixelDiffRatio

### DIFF
--- a/ui-tests/summary-page.ui.ts
+++ b/ui-tests/summary-page.ui.ts
@@ -356,7 +356,7 @@ test.describe("Summary Page Tests", () => {
   test("footer screenshot", async () => {
     await page.mouse.move(0, 0);
     const footer = page.locator("footer");
-    await expect(footer).toHaveScreenshot("footer.png", { threshold: 0.01 });
+    await expect(footer).toHaveScreenshot("footer.png", { maxDiffPixelRatio: 0.01 });
   });
 
   test.describe("External link checks", () => {


### PR DESCRIPTION
Footer's failing on over-strictness: use maxPixelDiffRatio instead